### PR TITLE
feature/892A - parse movey deps

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -13,6 +13,7 @@ anyhow = "1.0.66"
 toml_edit =  { version = "0.15.0", features = ["easy"] }
 reqwest = { version = "0.11.12", features = ["blocking", "json"] }
 serde = { version = "1.0.147", default-features = false }
+serde_json = "1.0.87"
 
 [dev-dependencies]
 assert_cmd = "2.0.6"

--- a/cli/src/base/mod.rs
+++ b/cli/src/base/mod.rs
@@ -1,2 +1,3 @@
 pub mod movey_login;
 pub mod movey_upload;
+pub mod move_package_resolver;

--- a/cli/src/base/move_package_resolver.rs
+++ b/cli/src/base/move_package_resolver.rs
@@ -1,8 +1,11 @@
 use std::{collections::HashMap, fs};
 
 use anyhow::{anyhow, bail, Context, Result};
-use serde::Deserialize;
-use toml_edit::easy::{self, Value};
+use reqwest::blocking::Client;
+use serde::{Deserialize, Serialize};
+use serde_json::json;
+use toml_edit::easy::{self, value::Table, Value};
+use utils::{env::MOVE_HOME, movey_credential};
 
 #[derive(Deserialize, Debug)]
 pub struct Dependencies {
@@ -20,33 +23,107 @@ pub struct MoveyResolver {
     pub packages: Option<HashMap<String, String>>,
 }
 
-pub struct MovePackageResolver {}
+#[derive(Debug, Serialize)]
+pub struct MovePackageResolver {
+    deps_map: HashMap<String, String>,
+    deps_resolved: HashMap<String, MoveDependency>,
+}
 
 impl MovePackageResolver {
+    fn new() -> Self {
+        MovePackageResolver {
+            deps_map: HashMap::new(),
+            deps_resolved: HashMap::new(),
+        }
+    }
+
     pub fn execute() -> Result<()> {
         let move_toml_content = String::from_utf8(
             fs::read("Move.toml").context("Not in Move package root directory")?,
         )?;
-        let deps = MovePackageResolver::parse_deps_from_toml(&move_toml_content)?;
-        println!("{:#?}", deps);
+
+        let mut deps = MovePackageResolver::new();
+        deps.parse_deps_from_toml(&move_toml_content)?;
+        deps.resolve_movey_deps(None)?;
+        let lock_file_content = deps.generate_lock_toml_content();
+
+        fs::write("Move.lock", lock_file_content)
+            .map_err(|e| anyhow!("Cannot write to Move.lock file. {e}"))?;
         Ok(())
     }
 
-    fn parse_deps_from_toml(toml_content: &str) -> Result<HashMap<String, String>> {
+    fn parse_deps_from_toml(&mut self, toml_content: &str) -> Result<()> {
         let toml = easy::from_str::<Dependencies>(toml_content)
             .map_err(|e| anyhow!("Wrong Move.toml format for Movey dependencies. Error: {e}"))?;
         if toml.dependencies.movey.resolver != "movey" {
-            bail!("The CLI only resolve Movey-style dependencies.")
+            bail!("The CLI only resolve Movey dependencies.")
         };
-
-        let mut res = HashMap::new();
-
         if let Some(offchain_deps) = toml.dependencies.movey.packages {
             for (key, value) in offchain_deps {
-                res.insert(key, value);
+                self.deps_map.insert(key, value);
             }
         };
-        return Ok(res);
+        Ok(())
+    }
+
+    fn resolve_movey_deps(&mut self, url: Option<&str>) -> Result<()> {
+        let url = match url {
+            Some(url) => url.to_owned(),
+            None => movey_credential::get_movey_url(&MOVE_HOME)?,
+        };
+        let schemes = self.deps_map.values().collect::<Vec<_>>();
+        let schemes_request = json!({
+            "schemes": schemes,
+        });
+        let client = Client::new();
+        let response = client
+            .post(&format!("{}/api/v1/packages/info", &url))
+            .json(&schemes_request)
+            .send();
+        match response {
+            Ok(response) => {
+                self.deps_resolved = response.json()?;
+                Ok(())
+            }
+            Err(_) => {
+                bail!("An unexpected error occurred. Please try again later");
+            }
+        }
+    }
+
+    fn generate_lock_toml_content(&self) -> String {
+        let mut lock_toml = Value::Table(Table::new());
+        let packages = Value::Array(
+            self.deps_resolved
+                .values()
+                .map(|e| Value::from(e.clone()))
+                .collect::<Vec<_>>(),
+        );
+        lock_toml
+            .as_table_mut()
+            .unwrap()
+            .insert(String::from("package"), packages);
+        lock_toml.to_string()
+    }
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize)]
+struct MoveDependency {
+    name: String,
+    version: String,
+    repository_url: String,
+    rev: String,
+    scheme: String,
+}
+
+impl From<MoveDependency> for Value {
+    fn from(dep: MoveDependency) -> Self {
+        let mut package = Table::new();
+        package.insert(String::from("name"), Value::String(dep.name));
+        package.insert(String::from("version"), Value::String(dep.version));
+        package.insert(String::from("repository_url"), Value::String(dep.repository_url));
+        package.insert(String::from("rev"), Value::String(dep.rev));
+        Value::Table(package)
     }
 }
 
@@ -67,13 +144,57 @@ mod tests {
             resolver = "movey"
             
             [dependencies.movey.packages]
-            movedemo-ea = "1.0.0"
-            movedemo-ea-02 = "0.5.0"
+            MoveDemo = "movedemo-ea:1.0.0"
+            MoveDemo2 = "movedemo-ea-02:0.5.0"
         "#;
-        let result = MovePackageResolver::parse_deps_from_toml(toml_content).unwrap();
-        assert!(result.contains_key("movedemo-ea"));
+        let mut result = MovePackageResolver::new();
+        result.parse_deps_from_toml(toml_content).unwrap();
+        assert!(result.deps_map.contains_key("MoveDemo"));
 
-        let sui_deps = result.get("movedemo-ea").unwrap();
-        assert!(sui_deps.contains("1.0.0"))
+        let sui_deps = result.deps_map.get("MoveDemo").unwrap();
+        assert!(sui_deps.contains("movedemo-ea:1.0.0"))
+    }
+
+    #[test]
+    fn generate_lock_toml_content_works() {
+        let mut resolver = MovePackageResolver::new();
+        let mut mock_deps_resolved = HashMap::new();
+        mock_deps_resolved.insert(
+            "movedemo-ea".to_owned(),
+            MoveDependency {
+                name: "movedemo".to_owned(),
+                version: "1.0.0".to_owned(),
+                repository_url: "repo_url".to_owned(),
+                rev: "rev1".to_owned(),
+                scheme: "movedemo-ea".to_owned(),
+            },
+        );
+        mock_deps_resolved.insert(
+            "movedemo-ea-02".to_owned(),
+            MoveDependency {
+                name: "movedemo".to_owned(),
+                version: "0.5.0".to_owned(),
+                repository_url: "repo_url_02".to_owned(),
+                rev: "rev2".to_owned(),
+                scheme: "movedemo-ea-02".to_owned(),
+            },
+        );
+        resolver.deps_resolved = mock_deps_resolved;
+        let lock_toml_content = resolver.generate_lock_toml_content();
+        let expected_1 = r#"[[package]]
+name = "movedemo"
+version = "1.0.0"
+repository_url = "repo_url"
+rev = "rev1"
+"#;
+        let expected_2 = r#"[[package]]
+name = "movedemo"
+version = "0.5.0"
+repository_url = "repo_url_02"
+rev = "rev2"
+"#;
+        // Because HashMap iterator does not preserve order
+        assert!(lock_toml_content.contains(expected_1));
+        assert!(lock_toml_content.contains(expected_2));
     }
 }

--- a/cli/src/base/move_package_resolver.rs
+++ b/cli/src/base/move_package_resolver.rs
@@ -1,0 +1,89 @@
+use std::{collections::HashMap, fs};
+
+use anyhow::{bail, Context, Result};
+use serde::Deserialize;
+use toml_edit::easy::{self, Value};
+
+#[derive(Deserialize, Debug)]
+pub struct Dependencies {
+    pub dependencies: MoveyDependencies,
+}
+
+#[derive(Deserialize, Debug)]
+pub struct MoveyDependencies {
+    pub movey: MoveyResolver,
+}
+
+#[derive(Deserialize, Debug)]
+pub struct MoveyResolver {
+    pub resolver: String,
+    pub packages: Option<HashMap<String, Value>>,
+    pub onchain: Option<HashMap<String, Value>>,
+}
+
+pub struct MovePackageResolver {}
+
+impl MovePackageResolver {
+    pub fn execute() -> Result<()> {
+        let move_toml_content = String::from_utf8(
+            fs::read("Move.toml").context("Not in Move package root directory")?,
+        )?;
+        let deps = MovePackageResolver::parse_deps_from_toml(&move_toml_content)?;
+        println!("{:#?}", deps);
+        Ok(())
+    }
+
+    fn parse_deps_from_toml(toml_content: &str) -> Result<HashMap<String, Value>> {
+        let toml = easy::from_str::<Dependencies>(toml_content)
+            .map_err(|e| bail!("Wrong Move.toml format for Movey dependencies. Error: {e}"))?;
+        if toml.dependencies.movey.resolver != "movey" {
+            bail!("The CLI only resolve Movey-style dependencies.")
+        };
+
+        let mut res = HashMap::new();
+
+        if let Some(offchain_deps) = toml.dependencies.movey.packages {
+            for (key, value) in offchain_deps {
+                res.insert(key, value);
+            }
+        };
+        if let Some(onchain_deps) = toml.dependencies.movey.onchain {
+            for (key, value) in onchain_deps {
+                res.insert(key, value);
+            }
+        }
+        return Ok(res);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_deps_from_toml() {
+        let toml_content = r#"
+            [package]
+            name = ""
+            version = ""
+
+            [dependencies]
+
+            [dependencies.movey]
+            resolver = "movey"
+
+            [dependencies.movey.packages]
+            Sui  = { ns = "sui/stdlib", version = "1.0.0" }
+            Move = "move-language/stdlib"
+
+            [dependencies.movey.onchain]
+            coin = { addr = "0x2", chain = "sui/devnet" }
+            aptos-network-core = "aptos/mainnet"
+        "#;
+        let result = MovePackageResolver::parse_deps_from_toml(toml_content).unwrap();
+        assert!(result.contains_key("Sui"));
+
+        let sui_deps = result.get("Sui").unwrap();
+        assert_eq!(sui_deps.as_table().unwrap().len(), 2)
+    }
+}

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -4,9 +4,10 @@ use clap::{crate_version, crate_description, crate_authors};
 use core::commands;
 use utils::error::Result;
 
-pub mod base;
+mod base;
 use base::movey_login::MoveyLogin;
 use base::movey_upload::MoveyUpload;
+use base::move_package_resolver::MovePackageResolver;
 
 /// Match commands
 pub fn cli_match() -> Result<()> {
@@ -33,6 +34,9 @@ pub fn cli_match() -> Result<()> {
         Some("upload") => {
             MoveyUpload::execute(None)?
         }
+        Some("move-package-resolver") => {
+            MovePackageResolver::execute()?
+        }
         _ => {
             // Arguments are required by default (in Clap)
             // This section should never execute and thus
@@ -51,7 +55,8 @@ pub fn cli_config() -> Result<clap::ArgMatches> {
         .about(crate_description!())
         .author(crate_authors!("\n"))
         .subcommand(App::new("login").about("Login to Movey"))
-        .subcommand(App::new("upload").about("Upload to Movey"));
+        .subcommand(App::new("upload").about("Upload to Movey"))
+        .subcommand(App::new("move-package-resolver").about("Parse dependencies from Move.toml"));
     // Get matches
     let cli_matches = cli_app.get_matches();
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,6 +14,7 @@ fn main() -> Result<()> {
     #[cfg(not(debug_assertions))]
     {
         setup_panic!();
+        // let _guard = slog_scope::set_global_logger(utils::logger::default_root_logger()?);
     }
 
     // Better Panic. Only enabled *when* debugging.
@@ -35,7 +36,6 @@ fn main() -> Result<()> {
     // the utils crate.
     //
     //utils::logger::setup_logging()?;
-    let _guard = slog_scope::set_global_logger(utils::logger::default_root_logger()?);
     let _log_guard = slog_stdlog::init()?;
 
     // Initialize Configuration

--- a/tests/test_cli.rs
+++ b/tests/test_cli.rs
@@ -4,7 +4,6 @@ extern crate predicates;
 
 use assert_cmd::prelude::*;
 use httpmock::{Method::POST, Mock, MockServer};
-use predicates::prelude::*;
 use serde_json::json;
 use toml_edit::easy::Value;
 
@@ -30,27 +29,11 @@ fn test_cli() {
 }
 
 #[test]
-#[ignore]
 fn test_version() {
-    let expected_version = format!("{CLI_EXE} 0.0.1\n");
+    let expected_version = format!("movey-cli 0.0.1\n");
     let mut cmd = Command::cargo_bin(CLI_EXE).expect("Calling binary failed");
-    cmd.arg("--version").assert().stdout(expected_version);
-}
-
-#[test]
-#[ignore]
-fn test_hazard_exit_code() {
-    let mut cmd = Command::cargo_bin(CLI_EXE).expect("Calling binary failed");
-    cmd.arg("hazard").assert().code(0);
-}
-
-#[test]
-#[ignore]
-fn test_hazard_stdout() {
-    let hazard_predicate =
-        predicate::function(|x: &str| x == "You got it right!\n" || x == "You got it wrong!\n");
-    let mut cmd = Command::cargo_bin(CLI_EXE).expect("Calling binary failed");
-    cmd.arg("hazard").assert().stdout(hazard_predicate);
+    let result = cmd.arg("--version").output().unwrap();
+    assert_eq!(String::from_utf8(result.stdout.to_vec()).unwrap(), expected_version)
 }
 
 const UPLOAD_PACKAGE_PATH: &str = "./tests/upload_tests";


### PR DESCRIPTION
Parse Movey dependencies from Move.toml file 

For example:
```
[dependencies]

[dependencies.movey]
resolver = "movey"

[dependencies.movey.packages]
sui = "1.0.0"
movedemo-ea = "1.0.0"

```
Will be parsed into
```
{
    "movedemo-ea": "1.0.0",
    "sui": "1.0.0",
}
```

And written into Move.lock file in the format similar to Cargo.lock file
```
[[package]]
name = "movedemo"
repository_ur = "..."
version = "..."
rev = "..."
```